### PR TITLE
add phaseType option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.pabuff</groupId>
   <artifactId>evs2dto</artifactId>
-  <version>1.53.6</version>
+  <version>1.53.7</version>
   <name>EVS2 DTO</name>
   <url>http://maven.apache.org</url>
 

--- a/src/main/java/org/pabuff/dto/MeterPhaseTypeEnum.java
+++ b/src/main/java/org/pabuff/dto/MeterPhaseTypeEnum.java
@@ -3,7 +3,8 @@ package org.pabuff.dto;
 public enum MeterPhaseTypeEnum {
     SINGLE_PHASE("single_phase", "Single Phase", "1p"),
     THREE_PHASE("three_phase", "Three Phase", "3p"),
-    THREE_PHASE_DIRECT("three_phase_direct", "Three Phase Direct", "3pd");
+    THREE_PHASE_DIRECT("three_phase_direct", "Three Phase Direct", "3pd"),
+    THREE_PHASE_CT("three_phase_ct", "Three Phase CT", "3pc");
 
     private final String value;
     private final String label;


### PR DESCRIPTION
This pull request introduces a new meter phase type to the `MeterPhaseTypeEnum` and updates the project version. The main changes are as follows:

Enum enhancements:

* Added a new enum value `THREE_PHASE_CT` to the `MeterPhaseTypeEnum` in `MeterPhaseTypeEnum.java` to support meters with a "Three Phase CT" configuration.

Project configuration:

* Updated the project version from `1.53.6` to `1.53.7` in `pom.xml`.